### PR TITLE
New zigpy init/01 new zigpy init

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ def is_raspberry_pi(raise_on_errors=False):
 
 
 requires = ['pyserial-asyncio',
-            'zigpy-homeassistant>=0.10.0',  # https://github.com/zigpy/zigpy/issues/190
+            'zigpy>=0.20.a2',
             ]
 if is_raspberry_pi():
     requires.append('RPi.GPIO')

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ def is_raspberry_pi(raise_on_errors=False):
 
 
 requires = ['pyserial-asyncio',
-            'zigpy>=0.20.0',
+            'zigpy>=0.20.1.a3',
             ]
 if is_raspberry_pi():
     requires.append('RPi.GPIO')

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ def is_raspberry_pi(raise_on_errors=False):
 
 
 requires = ['pyserial-asyncio',
-            'zigpy>=0.20.a2',
+            'zigpy>=0.20.0',
             ]
 if is_raspberry_pi():
     requires.append('RPi.GPIO')

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -3,23 +3,30 @@ from unittest import mock
 import pytest
 import zigpy.types as zigpy_types
 
+import zigpy_zigate.config as config
 import zigpy_zigate.types as t
 import zigpy_zigate.zigbee.application
+
+APP_CONFIG = zigpy_zigate.zigbee.application.ControllerApplication.SCHEMA(
+    {
+        config.CONF_DEVICE: {config.CONF_DEVICE_PATH: "/dev/null"},
+        config.CONF_DATABASE: None,
+    }
+)
 
 
 @pytest.fixture
 def app():
-    api = mock.MagicMock()
-    return zigpy_zigate.zigbee.application.ControllerApplication(api)
+    return zigpy_zigate.zigbee.application.ControllerApplication(APP_CONFIG)
 
 
 def test_zigpy_ieee(app):
     cluster = mock.MagicMock()
     cluster.cluster_id = 0x0000
-    data = b'\x01\x02\x03\x04\x05\x06\x07\x08'
+    data = b"\x01\x02\x03\x04\x05\x06\x07\x08"
 
     zigate_ieee, _ = t.EUI64.deserialize(data)
     app._ieee = zigpy_types.EUI64(zigate_ieee)
 
     dst_addr = app.get_dst_address(cluster)
-    assert dst_addr.serialize() == b'\x03' + data[::-1] + b'\x01'
+    assert dst_addr.serialize() == b"\x03" + data[::-1] + b"\x01"

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -3,11 +3,11 @@ from unittest import mock
 import pytest
 import serial_asyncio
 
-import zigpy_cc.config
+import zigpy_zigate.config
 from zigpy_zigate import uart
 
-DEVICE_CONFIG = zigpy_cc.config.SCHEMA_DEVICE(
-    {zigpy_cc.config.CONF_DEVICE_PATH: "/dev/null"}
+DEVICE_CONFIG = zigpy_zigate.config.SCHEMA_DEVICE(
+    {zigpy_zigate.config.CONF_DEVICE_PATH: "/dev/null"}
 )
 
 

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -3,7 +3,12 @@ from unittest import mock
 import pytest
 import serial_asyncio
 
+import zigpy_cc.config
 from zigpy_zigate import uart
+
+DEVICE_CONFIG = zigpy_cc.config.SCHEMA_DEVICE(
+    {zigpy_cc.config.CONF_DEVICE_PATH: "/dev/null"}
+)
 
 
 @pytest.fixture
@@ -16,7 +21,6 @@ def gw():
 @pytest.mark.asyncio
 async def test_connect(monkeypatch):
     api = mock.MagicMock()
-    portmock = mock.MagicMock()
 
     async def mock_conn(loop, protocol_factory, **kwargs):
         protocol = protocol_factory()
@@ -24,7 +28,7 @@ async def test_connect(monkeypatch):
         return None, protocol
     monkeypatch.setattr(serial_asyncio, 'create_serial_connection', mock_conn)
 
-    await uart.connect(portmock, 115200, api)
+    await uart.connect(DEVICE_CONFIG, api)
 
 
 def test_send(gw):

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ setenv = PYTHONPATH = {toxinidir}
 install_command = pip install {opts} {packages}
 commands = py.test --cov --cov-report=
 deps =
+    asynctest
     coveralls
     pytest
     pytest-cov

--- a/zigpy_zigate/api.py
+++ b/zigpy_zigate/api.py
@@ -1,15 +1,15 @@
-import logging
 import asyncio
 import binascii
 import functools
+import logging
+from typing import Any, Dict
 
-from . import uart
 from . import types as t
+from . import uart
 
 LOGGER = logging.getLogger(__name__)
 
 COMMAND_TIMEOUT = 3.0
-ZIGATE_BAUDRATE = 115200
 
 RESPONSES = {
     0x004D: (t.NWK, t.EUI64, t.uint8_t),
@@ -39,7 +39,9 @@ class NoResponseError(Exception):
 
 
 class ZiGate:
-    def __init__(self):
+    def __init__(self, device_config: Dict[str, Any]):
+        self._app = None
+        self._config = device_config
         self._uart = None
         self._callbacks = {}
         self._awaiting = {}
@@ -47,12 +49,21 @@ class ZiGate:
 
         self.network_state = None
 
-    async def connect(self, device, baudrate=ZIGATE_BAUDRATE):
+    @classmethod
+    async def new(cls, application, config: Dict[str, Any]) -> "ZiGate":
+        api = cls(config)
+        await api.connect()
+        api.set_application(application)
+        return api
+
+    async def connect(self):
         assert self._uart is None
-        self._uart = await uart.connect(device, ZIGATE_BAUDRATE, self)
+        self._uart = await uart.connect(self._config, self)
 
     def close(self):
-        return self._uart.close()
+        if self._uart:
+            self._uart.close()
+            self._uart = None
 
     def set_application(self, app):
         self._app = app

--- a/zigpy_zigate/api.py
+++ b/zigpy_zigate/api.py
@@ -4,8 +4,9 @@ import functools
 import logging
 from typing import Any, Dict
 
+import zigpy_zigate.uart
+
 from . import types as t
-from . import uart
 
 LOGGER = logging.getLogger(__name__)
 
@@ -50,7 +51,7 @@ class ZiGate:
         self.network_state = None
 
     @classmethod
-    async def new(cls, application, config: Dict[str, Any]) -> "ZiGate":
+    async def new(cls, config: Dict[str, Any], application=None) -> "ZiGate":
         api = cls(config)
         await api.connect()
         api.set_application(application)
@@ -58,7 +59,7 @@ class ZiGate:
 
     async def connect(self):
         assert self._uart is None
-        self._uart = await uart.connect(self._config, self)
+        self._uart = await zigpy_zigate.uart.connect(self._config, self)
 
     def close(self):
         if self._uart:

--- a/zigpy_zigate/config.py
+++ b/zigpy_zigate/config.py
@@ -1,0 +1,7 @@
+from zigpy.config import (  # noqa: F401 pylint: disable=unused-import
+    CONF_DATABASE,
+    CONF_DEVICE,
+    CONF_DEVICE_PATH,
+    CONFIG_SCHEMA,
+    SCHEMA_DEVICE,
+)

--- a/zigpy_zigate/uart.py
+++ b/zigpy_zigate/uart.py
@@ -2,7 +2,7 @@ import asyncio
 import binascii
 import logging
 import struct
-from typing import Any, Callable, Dict
+from typing import Any, Dict
 
 import serial  # noqa
 import serial.tools.list_ports

--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -10,13 +10,14 @@ import zigpy.util
 
 from zigpy_zigate import types as t
 from zigpy_zigate.api import NoResponseError, ZiGate
-from zigpy_zigate.config import CONF_DEVICE, CONFIG_SCHEMA
+from zigpy_zigate.config import CONF_DEVICE, CONFIG_SCHEMA, SCHEMA_DEVICE
 
 LOGGER = logging.getLogger(__name__)
 
 
 class ControllerApplication(zigpy.application.ControllerApplication):
     SCHEMA = CONFIG_SCHEMA
+    SCHEMA_DEVICE = SCHEMA_DEVICE
 
     def __init__(self, config: Dict[str, Any]):
         super().__init__(zigpy.config.ZIGPY_SCHEMA(config))


### PR DESCRIPTION
Implement new zigpy initialization and support for radio lib configuration schemas in https://github.com/zigpy/zigpy/commits/new-zigpy-init/dev

This would allow each radio lib to extend the zigpy configuration schema by adding radio specific configuration options.
Corresponding HA changes are currently in https://github.com/Adminiuga/home-assistant/tree/experimental/new-zigpy-init

I don't have a zigate so can't test, but once tested I'm going to publish new zigpy version.