### PR TITLE
WIP Add lightweight API probe method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # zigpy-zigate
 
-[![Build Status](https://travis-ci.com/doudz/zigpy-zigate.svg?branch=master)](https://travis-ci.com/doudz/zigpy-zigate)
+[![Build Status](https://travis-ci.com/zigpy/zigpy-zigate.svg?branch=master)](https://travis-ci.com/zigpy/zigpy-zigate)
 [![Coverage](https://coveralls.io/repos/github/doudz/zigpy-zigate/badge.svg?branch=master)](https://coveralls.io/github/doudz/zigpy-zigate?branch=master)
 
 **WARNING: EXPERIMENTAL! This project is under development as WIP (work in progress). Developer’s work provided “AS IS”.**
 
-[zigpy-zigate](https://github.com/doudz/zigpy-zigate) is a Python 3 implementation for the [Zigpy](https://github.com/zigpy/) project to implement [ZiGate](https://www.zigate.fr/) based [Zigbee](https://www.zigbee.org) radio devices.
+[zigpy-zigate](https://github.com/zigpy/zigpy-zigate) is a Python 3 implementation for the [Zigpy](https://github.com/zigpy/) project to implement [ZiGate](https://www.zigate.fr/) based [Zigbee](https://www.zigbee.org) radio devices.
 
-- https://github.com/doudz/zigpy-zigate
+- https://github.com/zigpy/zigpy-zigate
 
 ZiGate is a open source ZigBee adapter hardware that was initially launched on Kickstarter by @fairecasoimeme
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ def is_raspberry_pi(raise_on_errors=False):
 
 
 requires = ['pyserial-asyncio',
-            'zigpy-homeassistant>=0.10.0',  # https://github.com/zigpy/zigpy/issues/190
+            'zigpy>=0.20.a2',
             ]
 if is_raspberry_pi():
     requires.append('RPi.GPIO')

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ def is_raspberry_pi(raise_on_errors=False):
 
 
 requires = ['pyserial-asyncio',
-            'zigpy>=0.20.0',
+            'zigpy>=0.20.1.a3',
             ]
 if is_raspberry_pi():
     requires.append('RPi.GPIO')

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ def is_raspberry_pi(raise_on_errors=False):
 
 
 requires = ['pyserial-asyncio',
-            'zigpy>=0.20.a2',
+            'zigpy>=0.20.0',
             ]
 if is_raspberry_pi():
     requires.append('RPi.GPIO')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,14 +1,15 @@
+import asyncio
+
 import pytest
+import serial
 import serial_asyncio
-from asynctest import mock
+from asynctest import CoroutineMock, mock
 
 import zigpy_zigate.config as config
 import zigpy_zigate.uart
 from zigpy_zigate import api as zigate_api
 
-DEVICE_CONFIG = config.SCHEMA_DEVICE(
-    {config.CONF_DEVICE_PATH: "/dev/null"}
-)
+DEVICE_CONFIG = config.SCHEMA_DEVICE({config.CONF_DEVICE_PATH: "/dev/null"})
 
 
 @pytest.fixture
@@ -31,7 +32,8 @@ async def test_connect(monkeypatch):
         protocol = protocol_factory()
         loop.call_soon(protocol.connection_made, None)
         return None, protocol
-    monkeypatch.setattr(serial_asyncio, 'create_serial_connection', mock_conn)
+
+    monkeypatch.setattr(serial_asyncio, "create_serial_connection", mock_conn)
 
     await api.connect()
 
@@ -52,3 +54,40 @@ async def test_api_new(conn_mck):
     assert isinstance(api, zigate_api.ZiGate)
     assert conn_mck.call_count == 1
     assert conn_mck.await_count == 1
+
+
+@pytest.mark.asyncio
+@mock.patch.object(zigate_api.ZiGate, "set_raw_mode", new_callable=CoroutineMock)
+@mock.patch.object(zigpy_zigate.uart, "connect")
+async def test_probe_success(mock_connect, mock_raw_mode):
+    """Test device probing."""
+
+    res = await zigate_api.ZiGate.probe(DEVICE_CONFIG)
+    assert res is True
+    assert mock_connect.call_count == 1
+    assert mock_connect.await_count == 1
+    assert mock_connect.call_args[0][0] == DEVICE_CONFIG
+    assert mock_raw_mode.call_count == 1
+    assert mock_connect.return_value.close.call_count == 1
+
+
+@pytest.mark.asyncio
+@mock.patch.object(zigate_api.ZiGate, "set_raw_mode", side_effect=asyncio.TimeoutError)
+@mock.patch.object(zigpy_zigate.uart, "connect")
+@pytest.mark.parametrize(
+    "exception",
+    (asyncio.TimeoutError, serial.SerialException, zigate_api.NoResponseError),
+)
+async def test_probe_fail(mock_connect, mock_raw_mode, exception):
+    """Test device probing fails."""
+
+    mock_raw_mode.side_effect = exception
+    mock_connect.reset_mock()
+    mock_raw_mode.reset_mock()
+    res = await zigate_api.ZiGate.probe(DEVICE_CONFIG)
+    assert res is False
+    assert mock_connect.call_count == 1
+    assert mock_connect.await_count == 1
+    assert mock_connect.call_args[0][0] == DEVICE_CONFIG
+    assert mock_raw_mode.call_count == 1
+    assert mock_connect.return_value.close.call_count == 1

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -3,23 +3,30 @@ from unittest import mock
 import pytest
 import zigpy.types as zigpy_types
 
+import zigpy_zigate.config as config
 import zigpy_zigate.types as t
 import zigpy_zigate.zigbee.application
+
+APP_CONFIG = zigpy_zigate.zigbee.application.ControllerApplication.SCHEMA(
+    {
+        config.CONF_DEVICE: {config.CONF_DEVICE_PATH: "/dev/null"},
+        config.CONF_DATABASE: None,
+    }
+)
 
 
 @pytest.fixture
 def app():
-    api = mock.MagicMock()
-    return zigpy_zigate.zigbee.application.ControllerApplication(api)
+    return zigpy_zigate.zigbee.application.ControllerApplication(APP_CONFIG)
 
 
 def test_zigpy_ieee(app):
     cluster = mock.MagicMock()
     cluster.cluster_id = 0x0000
-    data = b'\x01\x02\x03\x04\x05\x06\x07\x08'
+    data = b"\x01\x02\x03\x04\x05\x06\x07\x08"
 
     zigate_ieee, _ = t.EUI64.deserialize(data)
     app._ieee = zigpy_types.EUI64(zigate_ieee)
 
     dst_addr = app.get_dst_address(cluster)
-    assert dst_addr.serialize() == b'\x03' + data[::-1] + b'\x01'
+    assert dst_addr.serialize() == b"\x03" + data[::-1] + b"\x01"

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -3,11 +3,11 @@ from unittest import mock
 import pytest
 import serial_asyncio
 
-import zigpy_cc.config
+import zigpy_zigate.config
 from zigpy_zigate import uart
 
-DEVICE_CONFIG = zigpy_cc.config.SCHEMA_DEVICE(
-    {zigpy_cc.config.CONF_DEVICE_PATH: "/dev/null"}
+DEVICE_CONFIG = zigpy_zigate.config.SCHEMA_DEVICE(
+    {zigpy_zigate.config.CONF_DEVICE_PATH: "/dev/null"}
 )
 
 

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -3,7 +3,12 @@ from unittest import mock
 import pytest
 import serial_asyncio
 
+import zigpy_cc.config
 from zigpy_zigate import uart
+
+DEVICE_CONFIG = zigpy_cc.config.SCHEMA_DEVICE(
+    {zigpy_cc.config.CONF_DEVICE_PATH: "/dev/null"}
+)
 
 
 @pytest.fixture
@@ -16,7 +21,6 @@ def gw():
 @pytest.mark.asyncio
 async def test_connect(monkeypatch):
     api = mock.MagicMock()
-    portmock = mock.MagicMock()
 
     async def mock_conn(loop, protocol_factory, **kwargs):
         protocol = protocol_factory()
@@ -24,7 +28,7 @@ async def test_connect(monkeypatch):
         return None, protocol
     monkeypatch.setattr(serial_asyncio, 'create_serial_connection', mock_conn)
 
-    await uart.connect(portmock, 115200, api)
+    await uart.connect(DEVICE_CONFIG, api)
 
 
 def test_send(gw):

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ setenv = PYTHONPATH = {toxinidir}
 install_command = pip install {opts} {packages}
 commands = py.test --cov --cov-report=
 deps =
+    asynctest
     coveralls
     pytest
     pytest-cov

--- a/zigpy_zigate/api.py
+++ b/zigpy_zigate/api.py
@@ -14,7 +14,7 @@ from . import types as t
 
 LOGGER = logging.getLogger(__name__)
 
-COMMAND_TIMEOUT = 3.0
+COMMAND_TIMEOUT = 1.5
 
 RESPONSES = {
     0x004D: (t.NWK, t.EUI64, t.uint8_t),

--- a/zigpy_zigate/api.py
+++ b/zigpy_zigate/api.py
@@ -1,15 +1,15 @@
-import logging
 import asyncio
 import binascii
 import functools
+import logging
+from typing import Any, Dict
 
-from . import uart
 from . import types as t
+from . import uart
 
 LOGGER = logging.getLogger(__name__)
 
 COMMAND_TIMEOUT = 3.0
-ZIGATE_BAUDRATE = 115200
 
 RESPONSES = {
     0x004D: (t.NWK, t.EUI64, t.uint8_t),
@@ -39,7 +39,9 @@ class NoResponseError(Exception):
 
 
 class ZiGate:
-    def __init__(self):
+    def __init__(self, device_config: Dict[str, Any]):
+        self._app = None
+        self._config = device_config
         self._uart = None
         self._callbacks = {}
         self._awaiting = {}
@@ -47,12 +49,21 @@ class ZiGate:
 
         self.network_state = None
 
-    async def connect(self, device, baudrate=ZIGATE_BAUDRATE):
+    @classmethod
+    async def new(cls, application, config: Dict[str, Any]) -> "ZiGate":
+        api = cls(config)
+        await api.connect()
+        api.set_application(application)
+        return api
+
+    async def connect(self):
         assert self._uart is None
-        self._uart = await uart.connect(device, ZIGATE_BAUDRATE, self)
+        self._uart = await uart.connect(self._config, self)
 
     def close(self):
-        return self._uart.close()
+        if self._uart:
+            self._uart.close()
+            self._uart = None
 
     def set_application(self, app):
         self._app = app

--- a/zigpy_zigate/api.py
+++ b/zigpy_zigate/api.py
@@ -4,8 +4,9 @@ import functools
 import logging
 from typing import Any, Dict
 
+import zigpy_zigate.uart
+
 from . import types as t
-from . import uart
 
 LOGGER = logging.getLogger(__name__)
 
@@ -50,7 +51,7 @@ class ZiGate:
         self.network_state = None
 
     @classmethod
-    async def new(cls, application, config: Dict[str, Any]) -> "ZiGate":
+    async def new(cls, config: Dict[str, Any], application=None) -> "ZiGate":
         api = cls(config)
         await api.connect()
         api.set_application(application)
@@ -58,7 +59,7 @@ class ZiGate:
 
     async def connect(self):
         assert self._uart is None
-        self._uart = await uart.connect(self._config, self)
+        self._uart = await zigpy_zigate.uart.connect(self._config, self)
 
     def close(self):
         if self._uart:

--- a/zigpy_zigate/config.py
+++ b/zigpy_zigate/config.py
@@ -1,0 +1,7 @@
+from zigpy.config import (  # noqa: F401 pylint: disable=unused-import
+    CONF_DATABASE,
+    CONF_DEVICE,
+    CONF_DEVICE_PATH,
+    CONFIG_SCHEMA,
+    SCHEMA_DEVICE,
+)

--- a/zigpy_zigate/uart.py
+++ b/zigpy_zigate/uart.py
@@ -2,7 +2,7 @@ import asyncio
 import binascii
 import logging
 import struct
-from typing import Any, Callable, Dict
+from typing import Any, Dict
 
 import serial  # noqa
 import serial.tools.list_ports

--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -19,6 +19,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     SCHEMA = CONFIG_SCHEMA
     SCHEMA_DEVICE = SCHEMA_DEVICE
 
+    probe = ZiGate.probe
+
     def __init__(self, config: Dict[str, Any]):
         super().__init__(zigpy.config.ZIGPY_SCHEMA(config))
         self._api: Optional[ZiGate] = None

--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -10,13 +10,14 @@ import zigpy.util
 
 from zigpy_zigate import types as t
 from zigpy_zigate.api import NoResponseError, ZiGate
-from zigpy_zigate.config import CONF_DEVICE, CONFIG_SCHEMA
+from zigpy_zigate.config import CONF_DEVICE, CONFIG_SCHEMA, SCHEMA_DEVICE
 
 LOGGER = logging.getLogger(__name__)
 
 
 class ControllerApplication(zigpy.application.ControllerApplication):
     SCHEMA = CONFIG_SCHEMA
+    SCHEMA_DEVICE = SCHEMA_DEVICE
 
     def __init__(self, config: Dict[str, Any]):
         super().__init__(zigpy.config.ZIGPY_SCHEMA(config))


### PR DESCRIPTION
**This PR depends on #27 and needs to be rebased after #27 goes through**

This PR adds a "lightweight" probe method to validate there's is a correct device on the selected port. If we get a reply to `set_raw_mode()` command, then we consider a correct device on the given port.
HA Core would use this probe method (instead of full blown `zigpy` load/startup) to validate config entry data.