### PR TITLE
Add GitHub PyPa GitHub action

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,26 @@
+name: Publish distributions to PyPI and TestPyPI
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build-and-publish:
+    name: Build and publish distributions to PyPI and TestPyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        version: 3.7
+    - name: Install wheel
+      run: >-
+        pip install wheel
+    - name: Build
+      run: >-
+        python3 setup.py sdist bdist_wheel
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Automatically publish packages to pypi index on branch tagging. 