### PR TITLE
New zigpy init/dev

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ def is_raspberry_pi(raise_on_errors=False):
 
 
 requires = ['pyserial-asyncio',
-            'zigpy-homeassistant>=0.10.0',  # https://github.com/zigpy/zigpy/issues/190
+            'zigpy>=0.20.1.a3',
             ]
 if is_raspberry_pi():
     requires.append('RPi.GPIO')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,14 +1,15 @@
+import asyncio
+
 import pytest
+import serial
 import serial_asyncio
-from asynctest import mock
+from asynctest import CoroutineMock, mock
 
 import zigpy_zigate.config as config
 import zigpy_zigate.uart
 from zigpy_zigate import api as zigate_api
 
-DEVICE_CONFIG = config.SCHEMA_DEVICE(
-    {config.CONF_DEVICE_PATH: "/dev/null"}
-)
+DEVICE_CONFIG = config.SCHEMA_DEVICE({config.CONF_DEVICE_PATH: "/dev/null"})
 
 
 @pytest.fixture
@@ -31,7 +32,8 @@ async def test_connect(monkeypatch):
         protocol = protocol_factory()
         loop.call_soon(protocol.connection_made, None)
         return None, protocol
-    monkeypatch.setattr(serial_asyncio, 'create_serial_connection', mock_conn)
+
+    monkeypatch.setattr(serial_asyncio, "create_serial_connection", mock_conn)
 
     await api.connect()
 
@@ -52,3 +54,40 @@ async def test_api_new(conn_mck):
     assert isinstance(api, zigate_api.ZiGate)
     assert conn_mck.call_count == 1
     assert conn_mck.await_count == 1
+
+
+@pytest.mark.asyncio
+@mock.patch.object(zigate_api.ZiGate, "set_raw_mode", new_callable=CoroutineMock)
+@mock.patch.object(zigpy_zigate.uart, "connect")
+async def test_probe_success(mock_connect, mock_raw_mode):
+    """Test device probing."""
+
+    res = await zigate_api.ZiGate.probe(DEVICE_CONFIG)
+    assert res is True
+    assert mock_connect.call_count == 1
+    assert mock_connect.await_count == 1
+    assert mock_connect.call_args[0][0] == DEVICE_CONFIG
+    assert mock_raw_mode.call_count == 1
+    assert mock_connect.return_value.close.call_count == 1
+
+
+@pytest.mark.asyncio
+@mock.patch.object(zigate_api.ZiGate, "set_raw_mode", side_effect=asyncio.TimeoutError)
+@mock.patch.object(zigpy_zigate.uart, "connect")
+@pytest.mark.parametrize(
+    "exception",
+    (asyncio.TimeoutError, serial.SerialException, zigate_api.NoResponseError),
+)
+async def test_probe_fail(mock_connect, mock_raw_mode, exception):
+    """Test device probing fails."""
+
+    mock_raw_mode.side_effect = exception
+    mock_connect.reset_mock()
+    mock_raw_mode.reset_mock()
+    res = await zigate_api.ZiGate.probe(DEVICE_CONFIG)
+    assert res is False
+    assert mock_connect.call_count == 1
+    assert mock_connect.await_count == 1
+    assert mock_connect.call_args[0][0] == DEVICE_CONFIG
+    assert mock_raw_mode.call_count == 1
+    assert mock_connect.return_value.close.call_count == 1

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -3,23 +3,30 @@ from unittest import mock
 import pytest
 import zigpy.types as zigpy_types
 
+import zigpy_zigate.config as config
 import zigpy_zigate.types as t
 import zigpy_zigate.zigbee.application
+
+APP_CONFIG = zigpy_zigate.zigbee.application.ControllerApplication.SCHEMA(
+    {
+        config.CONF_DEVICE: {config.CONF_DEVICE_PATH: "/dev/null"},
+        config.CONF_DATABASE: None,
+    }
+)
 
 
 @pytest.fixture
 def app():
-    api = mock.MagicMock()
-    return zigpy_zigate.zigbee.application.ControllerApplication(api)
+    return zigpy_zigate.zigbee.application.ControllerApplication(APP_CONFIG)
 
 
 def test_zigpy_ieee(app):
     cluster = mock.MagicMock()
     cluster.cluster_id = 0x0000
-    data = b'\x01\x02\x03\x04\x05\x06\x07\x08'
+    data = b"\x01\x02\x03\x04\x05\x06\x07\x08"
 
     zigate_ieee, _ = t.EUI64.deserialize(data)
     app._ieee = zigpy_types.EUI64(zigate_ieee)
 
     dst_addr = app.get_dst_address(cluster)
-    assert dst_addr.serialize() == b'\x03' + data[::-1] + b'\x01'
+    assert dst_addr.serialize() == b"\x03" + data[::-1] + b"\x01"

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -3,7 +3,12 @@ from unittest import mock
 import pytest
 import serial_asyncio
 
+import zigpy_zigate.config
 from zigpy_zigate import uart
+
+DEVICE_CONFIG = zigpy_zigate.config.SCHEMA_DEVICE(
+    {zigpy_zigate.config.CONF_DEVICE_PATH: "/dev/null"}
+)
 
 
 @pytest.fixture
@@ -16,7 +21,6 @@ def gw():
 @pytest.mark.asyncio
 async def test_connect(monkeypatch):
     api = mock.MagicMock()
-    portmock = mock.MagicMock()
 
     async def mock_conn(loop, protocol_factory, **kwargs):
         protocol = protocol_factory()
@@ -24,7 +28,7 @@ async def test_connect(monkeypatch):
         return None, protocol
     monkeypatch.setattr(serial_asyncio, 'create_serial_connection', mock_conn)
 
-    await uart.connect(portmock, 115200, api)
+    await uart.connect(DEVICE_CONFIG, api)
 
 
 def test_send(gw):

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ setenv = PYTHONPATH = {toxinidir}
 install_command = pip install {opts} {packages}
 commands = py.test --cov --cov-report=
 deps =
+    asynctest
     coveralls
     pytest
     pytest-cov

--- a/zigpy_zigate/__init__.py
+++ b/zigpy_zigate/__init__.py
@@ -1,5 +1,5 @@
 MAJOR_VERSION = 0
-MINOR_VERSION = 5
-PATCH_VERSION = '1'
+MINOR_VERSION = 6
+PATCH_VERSION = '0'
 __short_version__ = '{}.{}'.format(MAJOR_VERSION, MINOR_VERSION)
 __version__ = '{}.{}'.format(__short_version__, PATCH_VERSION)

--- a/zigpy_zigate/api.py
+++ b/zigpy_zigate/api.py
@@ -48,7 +48,6 @@ class ZiGate:
         self._app = None
         self._config = device_config
         self._uart = None
-        self._callbacks = {}
         self._awaiting = {}
         self._status_awaiting = {}
 
@@ -157,20 +156,11 @@ class ZiGate:
                            security, radius, payload], COMMANDS[0x0530])
         return await self.command(0x0530, data)
 
-    def add_callback(self, cb):
-        id_ = hash(cb)
-        while id_ in self._callbacks:
-            id_ += 1
-        self._callbacks[id_] = cb
-        return id_
-
-    def remove_callback(self, id_):
-        return self._callbacks.pop(id_)
-
     def handle_callback(self, *args):
-        for handler in self._callbacks.values():
+        """run application callback handler"""
+        if self._app:
             try:
-                handler(*args)
+                self._app.zigate_callback_handler(*args)
             except Exception as e:
                 LOGGER.exception("Exception running handler", exc_info=e)
 

--- a/zigpy_zigate/api.py
+++ b/zigpy_zigate/api.py
@@ -4,13 +4,17 @@ import functools
 import logging
 from typing import Any, Dict
 
+import serial
+import zigpy.exceptions
+
+import zigpy_zigate.config
 import zigpy_zigate.uart
 
 from . import types as t
 
 LOGGER = logging.getLogger(__name__)
 
-COMMAND_TIMEOUT = 3.0
+COMMAND_TIMEOUT = 1.5
 
 RESPONSES = {
     0x004D: (t.NWK, t.EUI64, t.uint8_t),
@@ -35,7 +39,7 @@ COMMANDS = {
 }
 
 
-class NoResponseError(Exception):
+class NoResponseError(zigpy.exceptions.APIException):
     pass
 
 
@@ -169,3 +173,30 @@ class ZiGate:
                 handler(*args)
             except Exception as e:
                 LOGGER.exception("Exception running handler", exc_info=e)
+
+    @classmethod
+    async def probe(cls, device_config: Dict[str, Any]) -> bool:
+        """Probe port for the device presence."""
+        api = cls(zigpy_zigate.config.SCHEMA_DEVICE(device_config))
+        try:
+            await asyncio.wait_for(api._probe(), timeout=COMMAND_TIMEOUT)
+            return True
+        except (
+            asyncio.TimeoutError,
+            serial.SerialException,
+            zigpy.exceptions.ZigbeeException,
+        ) as exc:
+            LOGGER.debug(
+                "Unsuccessful radio probe of '%s' port",
+                device_config[zigpy_zigate.config.CONF_DEVICE_PATH],
+                exc_info=exc,
+            )
+        finally:
+            api.close()
+
+        return False
+
+    async def _probe(self) -> None:
+        """Open port and try sending a command"""
+        await self.connect()
+        await self.set_raw_mode()

--- a/zigpy_zigate/config.py
+++ b/zigpy_zigate/config.py
@@ -1,0 +1,7 @@
+from zigpy.config import (  # noqa: F401 pylint: disable=unused-import
+    CONF_DATABASE,
+    CONF_DEVICE,
+    CONF_DEVICE_PATH,
+    CONFIG_SCHEMA,
+    SCHEMA_DEVICE,
+)

--- a/zigpy_zigate/uart.py
+++ b/zigpy_zigate/uart.py
@@ -1,13 +1,17 @@
 import asyncio
+import binascii
 import logging
+import struct
+from typing import Any, Dict
+
 import serial  # noqa
 import serial.tools.list_ports
-import binascii
-import struct
-
 import serial_asyncio
 
+from zigpy_zigate.config import CONF_DEVICE_PATH
+
 LOGGER = logging.getLogger(__name__)
+ZIGATE_BAUDRATE = 115200
 
 
 class Gateway(asyncio.Protocol):
@@ -108,13 +112,14 @@ class Gateway(asyncio.Protocol):
         return length
 
 
-async def connect(port, baudrate, api, loop=None):
+async def connect(device_config: Dict[str, Any], api, loop=None):
     if loop is None:
         loop = asyncio.get_event_loop()
 
     connected_future = asyncio.Future()
     protocol = Gateway(api, connected_future)
 
+    port = device_config[CONF_DEVICE_PATH]
     if port.startswith('pizigate:'):
         await set_pizigate_running_mode()
         port = port.split(':', 1)[1]
@@ -130,12 +135,13 @@ async def connect(port, baudrate, api, loop=None):
                 LOGGER.info('ZiGate probably found at %s', port)
             else:
                 LOGGER.error('Unable to find ZiGate using auto mode')
+                raise serial.SerialException("Unable to find Zigate using auto mode")
 
     _, protocol = await serial_asyncio.create_serial_connection(
         loop,
         lambda: protocol,
         url=port,
-        baudrate=baudrate,
+        baudrate=ZIGATE_BAUDRATE,
         parity=serial.PARITY_NONE,
         stopbits=serial.STOPBITS_ONE,
         xonxoff=False,

--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -19,6 +19,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     SCHEMA = CONFIG_SCHEMA
     SCHEMA_DEVICE = SCHEMA_DEVICE
 
+    probe = ZiGate.probe
+
     def __init__(self, config: Dict[str, Any]):
         super().__init__(zigpy.config.ZIGPY_SCHEMA(config))
         self._api: Optional[ZiGate] = None

--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -33,8 +33,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     async def startup(self, auto_form=False):
         """Perform a complete application startup"""
-        self._api = ZiGate.new(self._config[CONF_DEVICE], self)
-        self._api.add_callback(self.zigate_callback_handler)
+        self._api = await ZiGate.new(self._config[CONF_DEVICE], self)
         await self._api.set_raw_mode()
         version, lqi = await self._api.version()
         version = '{:x}'.format(version[1])

--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -1,22 +1,27 @@
 import asyncio
 import logging
+from typing import Any, Dict, Optional
 
 import zigpy.application
+import zigpy.config
 import zigpy.device
 import zigpy.types
 import zigpy.util
+
 from zigpy_zigate import types as t
-from zigpy_zigate.api import NoResponseError
+from zigpy_zigate.api import NoResponseError, ZiGate
+from zigpy_zigate.config import CONF_DEVICE, CONFIG_SCHEMA, SCHEMA_DEVICE
 
 LOGGER = logging.getLogger(__name__)
 
 
 class ControllerApplication(zigpy.application.ControllerApplication):
-    def __init__(self, api, database_file=None):
-        super().__init__(database_file=database_file)
-        self._api = api
-        self._api.add_callback(self.zigate_callback_handler)
-        api.set_application(self)
+    SCHEMA = CONFIG_SCHEMA
+    SCHEMA_DEVICE = SCHEMA_DEVICE
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(zigpy.config.ZIGPY_SCHEMA(config))
+        self._api: Optional[ZiGate] = None
 
         self._pending = {}
 
@@ -26,6 +31,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     async def startup(self, auto_form=False):
         """Perform a complete application startup"""
+        self._api = ZiGate.new(self._config[CONF_DEVICE], self)
+        self._api.add_callback(self.zigate_callback_handler)
         await self._api.set_raw_mode()
         version, lqi = await self._api.version()
         version = '{:x}'.format(version[1])


### PR DESCRIPTION
Merge PR to add the following:

#32 A "lightweight" probe method to validate there's is a correct device on the selected port. If we get a reply to set_raw_mode() command, then we consider a correct device on the given port.
HA Core would use this probe method (instead of full blown zigpy load/startup) to validate config entry data.

#30 Implement new zigpy initialization and support for radio lib configuration schemas in https://github.com/zigpy/zigpy/commits/new-zigpy-init/dev

This would allow each radio lib to extend the zigpy configuration schema by adding radio specific configuration options. Corresponding 
HA changes are currently in https://github.com/Adminiuga/home-assistant/tree/experimental/new-zigpy-init
