### PR TITLE
Syncup with zigpy==0.23.0 changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,8 @@ language: python
 matrix:
   fast_finish: true
   include:
-    - python: "3.6"
+    - python: "3.7"
       env: TOXENV=lint
-    - python: "3.6"
-      env: TOXENV=py36
     - python: "3.7"
       env: TOXENV=py37
     - python: "3.8"

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ def is_raspberry_pi(raise_on_errors=False):
 
     return True
 
+
 requires = [
     'pyserial-asyncio',
     'zigpy>=0.22.2',

--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,11 @@ def is_raspberry_pi(raise_on_errors=False):
 
     return True
 
+requires = [
+    'pyserial-asyncio',
+    'zigpy>=0.22.2',
+]
 
-requires = ['pyserial-asyncio',
-            'zigpy>=0.20.1.a3',
-            ]
 if is_raspberry_pi():
     requires.append('RPi.GPIO')
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36, py37, py38, lint
+envlist = py37, py38, lint
 skip_missing_interpreters = True
 
 [testenv]

--- a/zigpy_zigate/types.py
+++ b/zigpy_zigate/types.py
@@ -129,8 +129,12 @@ class EUI64(zigpy.types.EUI64):
         return super().serialize()[::-1]
 
 
-class NWK(zigpy.types.HexRepr, uint16_t):
-    pass
+class NWK(uint16_t):
+    def __repr__(self):
+        return "0x{:04x}".format(self)
+
+    def __str__(self):
+        return "0x{:04x}".format(self)
 
 
 class ADDRESS_MODE(uint8_t, enum.Enum):


### PR DESCRIPTION
Drop python 3.6
Use own hex representation for NWK class.
Dependency on zipgy, instead of zigpy-homeassistant