### PR TITLE
Update setup.py to fix URL + consolidate setup dependencies format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,11 +48,6 @@ def is_raspberry_pi(raise_on_errors=False):
     return True
 
 
-requires = [
-    'pyserial-asyncio',
-    'zigpy>=0.22.2',
-]
-
 if is_raspberry_pi():
     requires.append('RPi.GPIO')
 
@@ -66,12 +61,15 @@ setup(
     description="A library which communicates with ZiGate radios for zigpy",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="http://github.com/doudz/zigpy-zigate",
+    url="http://github.com/zigpy/zigpy-zigate",
     author="Sébastien RAMAGE",
     author_email="sebatien.ramage@gmail.com",
     license="GPL-3.0",
     packages=find_packages(exclude=['*.tests']),
-    install_requires=requires,
+    install_requires=[
+        "pyserial-asyncio",
+        "zigpy>=0.22.2",
+    ],
     tests_require=[
         'pytest',
     ],


### PR DESCRIPTION
Updates GitHub URL and moves "pyserial-asyncio" and "zigpy>=0.22.2" from requires to requires to install_requires under setup

Makes format more similar to bellows setup.py https://raw.githubusercontent.com/zigpy/bellows/master/setup.py

Still, that is not exactly same format in setup.py as for zigpy or or for setup.py in any other the radio libraries so not quite consistent.