### PR TITLE
Update README.md with two more developer references

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Tagged versions are also released via PyPI
 Documents that layout the serial protocol used for ZiGate serial interface communication can be found here:
 
 - https://github.com/fairecasoimeme/ZiGate/tree/master/Protocol
+- https://github.com/Neonox31/zigate
+- https://github.com/nouknouk/node-zigate
 
 ## How to contribute
 


### PR DESCRIPTION
@doudz the https://github.com/Neonox31/zigate and https://github.com/nouknouk/node-zigate libraries by @Neonox31 and @nouknouk respectively can help developers in understanding the protocol and implementation of ZiGate adapters. 

Neonox31's zigate library converts ZiGate frames into human readable messages and vice versa, and the node-zigate project by nouknouk  aims to provide low-level and high-level APIs for managing the Zigate USB TTL adapter in node.js