### PR TITLE
Bump up dependencies on pyserial and pyserial-asyncio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ def is_raspberry_pi(raise_on_errors=False):
 
 
 requires = [
-    'pyserial-asyncio',
+    'pyserial==3.5',
+    'pyserial-asyncio==0.5',
     'pyusb>=1.1.0',
     'zigpy>=0.22.2',
 ]

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,8 @@ def is_raspberry_pi(raise_on_errors=False):
 
 
 requires = [
-    'pyserial==3.5',
-    'pyserial-asyncio==0.5',
+    'pyserial>=3.5',
+    'pyserial-asyncio>=0.5',
     'pyusb>=1.1.0',
     'zigpy>=0.22.2',
 ]


### PR DESCRIPTION
Bump up dependencies on pyserial and pyserial-asyncio for projects other projects that use this library but are not Home Assistant.

Adminiuga did the same dependency version bump for Home Assistant in https://github.com/home-assistant/core/pull/44089

pyserial-asyncio depends on pyserial and this bumps pyserial-asyncio to 0.5 version release and pyserial to 3.5 version release.

https://github.com/pyserial/pyserial-asyncio/releases/tag/v0.5

https://github.com/pyserial/pyserial/releases/tag/v3.5