### PR TITLE
Working with pure raw mode of NXP chip

### DIFF
--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -118,6 +118,12 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             #     LOGGER.debug('Start pairing {} (1st device announce)'.format(nwk))
             #     self._pending_join.append(nwk)
         elif msg == 0x8002:
+            if response[1] == 0x0 and response[2] == 0x13:
+                nwk = response[5].address
+                ieee = zigpy.types.EUI64(response[7][3:11])
+                parent_nwk = 0
+                self.handle_join(nwk, ieee, parent_nwk)
+                return
             try:
                 if response[5].address_mode == t.ADDRESS_MODE.NWK:
                     device = self.get_device(nwk=response[5].address)


### PR DESCRIPTION
This patch adds initial support for other firmware for NXP chips jn5168/5169 and others that has similar to zigate protocol.

My comrades are working on the firmware that uses "true" raw mode for NXP chips.
https://github.com/openlumi/JN-ZigbeeNodeControlBridge-firmware

 It uses raw mode for join requests too, so it is required to parse that frame to support joining. 
 It is supported in zigbee2mqtt application https://github.com/Koenkk/zigbee-herdsman/blob/6d7adca45f3154bac522dd33a2bc64f908a30c3c/src/adapter/zigate/driver/zigate.ts#L316-L324
 
 I'd like to add support to ZHA in Home Assistant. 