### PR TITLE
Use Network Security level when APS Raw 

### DIFF
--- a/zigpy_zigate/api.py
+++ b/zigpy_zigate/api.py
@@ -319,7 +319,7 @@ class ZiGate:
         return await self.command(0x0026, data)
 
     async def raw_aps_data_request(self, addr, src_ep, dst_ep, profile,
-                                   cluster, payload, addr_mode=2, security=0):
+                                   cluster, payload, addr_mode=2, security=0x02:
         '''
         Send raw APS Data request
         '''


### PR DESCRIPTION
APS Raw Command should be using Network level security 

0x02 : ZPS_E_APL_AF_SECURE_NWK (Network-level security using network key)

https://github.com/zigpy/zigpy/discussions/753