### PR TITLE
Switch from `RPi.GPIO` to `gpiozero`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,80 +1,29 @@
 """Setup module for zigpy-zigate"""
-import os
+
+import pathlib
 
 from setuptools import find_packages, setup
 from zigpy_zigate import __version__
-
-
-# extracted from https://raspberrypi.stackexchange.com/questions/5100/detect-that-a-python-program-is-running-on-the-pi
-def is_raspberry_pi(raise_on_errors=False):
-    """Checks if Raspberry PI.
-
-    :return:
-    """
-    try:
-        with open('/proc/cpuinfo', 'r') as cpuinfo:
-            found = False
-            for line in cpuinfo:
-                if line.startswith('Hardware'):
-                    found = True
-                    label, value = line.strip().split(':', 1)
-                    value = value.strip()
-                    if value not in (
-                        'BCM2708',
-                        'BCM2709',
-                        'BCM2835',
-                        'BCM2836'
-                    ):
-                        if raise_on_errors:
-                            raise ValueError(
-                                'This system does not appear to be a '
-                                'Raspberry Pi.'
-                            )
-                        else:
-                            return False
-            if not found:
-                if raise_on_errors:
-                    raise ValueError(
-                        'Unable to determine if this system is a Raspberry Pi.'
-                    )
-                else:
-                    return False
-    except IOError:
-        if raise_on_errors:
-            raise ValueError('Unable to open `/proc/cpuinfo`.')
-        else:
-            return False
-
-    return True
-
-
-requires = [
-    'pyserial>=3.5',
-    'pyserial-asyncio>=0.5; platform_system!="Windows"',
-    'pyserial-asyncio!=0.5; platform_system=="Windows"',  # 0.5 broke writesv
-    'pyusb>=1.1.0',
-    'zigpy>=0.47.0',
-]
-
-if is_raspberry_pi():
-    requires.append('RPi.GPIO')
-
-this_directory = os.path.join(os.path.abspath(os.path.dirname(__file__)))
-with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
-    long_description = f.read()
 
 setup(
     name="zigpy-zigate",
     version=__version__,
     description="A library which communicates with ZiGate radios for zigpy",
-    long_description=long_description,
+    long_description=(pathlib.Path(__file__).parent / "README.md").read_text(),
     long_description_content_type="text/markdown",
     url="http://github.com/zigpy/zigpy-zigate",
     author="Sébastien RAMAGE",
     author_email="sebatien.ramage@gmail.com",
     license="GPL-3.0",
     packages=find_packages(exclude=['tests']),
-    install_requires=requires,
+    install_requires=[
+        'pyserial>=3.5',
+        'pyserial-asyncio>=0.5; platform_system!="Windows"',
+        'pyserial-asyncio!=0.5; platform_system=="Windows"',  # 0.5 broke writes
+        'pyusb>=1.1.0',
+        'zigpy>=0.47.0',
+        'gpiozero',
+    ],
     tests_require=[
         'pytest',
         'pytest-asyncio',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -73,8 +73,6 @@ async def test_probe_success(mock_raw_mode, port, monkeypatch):
     DEVICE_CONFIG = zigpy_zigate.config.SCHEMA_DEVICE(
         {zigpy_zigate.config.CONF_DEVICE_PATH: port}
     )
-    sys.modules['RPi'] = MagicMock()
-    sys.modules['RPi.GPIO'] = MagicMock()
     res = await zigate_api.ZiGate.probe(DEVICE_CONFIG)
     assert res is True
     assert mock_raw_mode.call_count == 1

--- a/zigpy_zigate/common.py
+++ b/zigpy_zigate/common.py
@@ -22,7 +22,7 @@ class UnclosableOutputDevice(OutputDevice):
     """
 
     def __init__(
-        self, pin=None, *, active_high=True, initial_value=None, pin_factory=None
+        self, pin=None, *, active_high=True, initial_value=False, pin_factory=None
     ):
         super().__init__(
             pin,
@@ -80,8 +80,8 @@ def is_zigate_wifi(port):
 def set_pizigate_running_mode():
     LOGGER.info('Put PiZiGate in running mode')
 
-    gpio0 = UnclosableOutputDevice(pin=GPIO_PIN0)
-    gpio2 = UnclosableOutputDevice(pin=GPIO_PIN2)
+    gpio0 = UnclosableOutputDevice(pin=GPIO_PIN0, initial_state=None)
+    gpio2 = UnclosableOutputDevice(pin=GPIO_PIN2, initial_state=None)
 
     gpio2.on()
     time.sleep(0.5)
@@ -96,8 +96,8 @@ def set_pizigate_running_mode():
 def set_pizigate_flashing_mode():
     LOGGER.info('Put PiZiGate in flashing mode')
 
-    gpio0 = UnclosableOutputDevice(pin=GPIO_PIN0)
-    gpio2 = UnclosableOutputDevice(pin=GPIO_PIN2)
+    gpio0 = UnclosableOutputDevice(pin=GPIO_PIN0, initial_state=None)
+    gpio2 = UnclosableOutputDevice(pin=GPIO_PIN2, initial_state=None)
 
     gpio2.off()
     time.sleep(0.5)

--- a/zigpy_zigate/common.py
+++ b/zigpy_zigate/common.py
@@ -53,48 +53,38 @@ def is_zigate_wifi(port):
     return port.startswith('socket://')
 
 
-def async_run_in_executor(function):
-    """Decorator to make a sync function async."""
-
-    async def replacement(*args):
-        return asyncio.get_running_loop().run_in_executor(None, function, *args)
-
-    replacement._sync_func = function
-
-    return replacement
-
-
-@async_run_in_executor
 def set_pizigate_running_mode():
     from gpiozero import OutputDevice
 
     LOGGER.info('Put PiZiGate in running mode')
 
-    with OutputDevice(pin=17) as gpio17, OutputDevice(pin=27) as gpio27:
-        gpio27.on()
+    with OutputDevice(pin=17) as gpio0, OutputDevice(pin=27) as gpio2:
+        gpio2.on()
         time.sleep(0.5)
-        gpio17.off()
+
+        gpio0.off()
         time.sleep(0.5)
-        gpio17.on()
+
+        gpio0.on()
         time.sleep(0.5)
 
 
-@async_run_in_executor
 def set_pizigate_flashing_mode():
     from gpiozero import OutputDevice
 
     LOGGER.info('Put PiZiGate in flashing mode')
 
-    with OutputDevice(pin=17) as gpio17, OutputDevice(pin=27) as gpio27:
-        gpio27.off()
+    with OutputDevice(pin=17) as gpio0, OutputDevice(pin=27) as gpio2:
+        gpio2.off()
         time.sleep(0.5)
-        gpio17.off()
+
+        gpio0.off()
         time.sleep(0.5)
-        gpio17.on()
+
+        gpio0.on()
         time.sleep(0.5)
 
 
-@async_run_in_executor
 def ftdi_set_bitmode(dev, bitmask):
     '''
     Set mode for ZiGate DIN module
@@ -110,7 +100,6 @@ def ftdi_set_bitmode(dev, bitmask):
     dev.ctrl_transfer(bmRequestType, SIO_SET_BITMODE_REQUEST, wValue)
 
 
-@async_run_in_executor
 def set_zigatedin_running_mode():
     import usb
 
@@ -125,7 +114,6 @@ def set_zigatedin_running_mode():
     time.sleep(0.5)
 
 
-@async_run_in_executor
 def set_zigatedin_flashing_mode():
     import usb
 
@@ -144,3 +132,21 @@ def set_zigatedin_flashing_mode():
     time.sleep(0.5)
     ftdi_set_bitmode(dev, 0xCC)
     time.sleep(0.5)
+
+
+def async_run_in_executor(function):
+    """Decorator to make a sync function async."""
+
+    async def replacement(*args):
+        return asyncio.get_running_loop().run_in_executor(None, function, *args)
+
+    replacement._sync_func = function
+
+    return replacement
+
+
+# Create async version of all of the above functions
+async_set_pizigate_running_mode = async_run_in_executor(set_pizigate_running_mode)
+async_set_pizigate_flashing_mode = async_run_in_executor(set_pizigate_flashing_mode)
+async_set_zigatedin_running_mode = async_run_in_executor(set_zigatedin_running_mode)
+async_set_zigatedin_flashing_mode = async_run_in_executor(set_zigatedin_flashing_mode)

--- a/zigpy_zigate/common.py
+++ b/zigpy_zigate/common.py
@@ -69,15 +69,14 @@ def set_pizigate_running_mode():
     from gpiozero import OutputDevice
 
     LOGGER.info('Put PiZiGate in running mode')
-    gpio17 = OutputDevice(pin=17)
-    gpio27 = OutputDevice(pin=27)
 
-    gpio27.on()
-    time.sleep(0.5)
-    gpio17.off()
-    time.sleep(0.5)
-    gpio17.on()
-    time.sleep(0.5)
+    with OutputDevice(pin=17) as gpio17, OutputDevice(pin=27) as gpio27:
+        gpio27.on()
+        time.sleep(0.5)
+        gpio17.off()
+        time.sleep(0.5)
+        gpio17.on()
+        time.sleep(0.5)
 
 
 @async_run_in_executor
@@ -85,15 +84,14 @@ def set_pizigate_flashing_mode():
     from gpiozero import OutputDevice
 
     LOGGER.info('Put PiZiGate in flashing mode')
-    gpio17 = OutputDevice(pin=17)
-    gpio27 = OutputDevice(pin=27)
 
-    gpio27.off()
-    time.sleep(0.5)
-    gpio17.off()
-    time.sleep(0.5)
-    gpio17.on()
-    time.sleep(0.5)
+    with OutputDevice(pin=17) as gpio17, OutputDevice(pin=27) as gpio27:
+        gpio27.off()
+        time.sleep(0.5)
+        gpio17.off()
+        time.sleep(0.5)
+        gpio17.on()
+        time.sleep(0.5)
 
 
 @async_run_in_executor

--- a/zigpy_zigate/common.py
+++ b/zigpy_zigate/common.py
@@ -6,7 +6,31 @@ import serial
 import logging
 import asyncio
 
+from gpiozero import OutputDevice
+
+
 LOGGER = logging.getLogger(__name__)
+
+GPIO_PIN0 = 17
+GPIO_PIN2 = 27
+
+
+class UnclosableOutputDevice(OutputDevice):
+    """
+    `OutputDevice` that never closes its pins. Allows for the last-written pin state to
+    be retained even after the `OutputDevice` is garbage collected.
+    """
+
+    def __init__(
+        self, pin=None, *, active_high=True, initial_value=None, pin_factory=None
+    ):
+        super().__init__(
+            pin,
+            active_high=active_high,
+            initial_value=initial_value,
+            pin_factory=pin_factory,
+        )
+        self._pin.close = lambda *args, **kwargs: None
 
 
 def discover_port():
@@ -54,35 +78,35 @@ def is_zigate_wifi(port):
 
 
 def set_pizigate_running_mode():
-    from gpiozero import OutputDevice
-
     LOGGER.info('Put PiZiGate in running mode')
 
-    with OutputDevice(pin=17) as gpio0, OutputDevice(pin=27) as gpio2:
-        gpio2.on()
-        time.sleep(0.5)
+    gpio0 = UnclosableOutputDevice(pin=GPIO_PIN0)
+    gpio2 = UnclosableOutputDevice(pin=GPIO_PIN2)
 
-        gpio0.off()
-        time.sleep(0.5)
+    gpio2.on()
+    time.sleep(0.5)
 
-        gpio0.on()
-        time.sleep(0.5)
+    gpio0.off()
+    time.sleep(0.5)
+
+    gpio0.on()
+    time.sleep(0.5)
 
 
 def set_pizigate_flashing_mode():
-    from gpiozero import OutputDevice
-
     LOGGER.info('Put PiZiGate in flashing mode')
 
-    with OutputDevice(pin=17) as gpio0, OutputDevice(pin=27) as gpio2:
-        gpio2.off()
-        time.sleep(0.5)
+    gpio0 = UnclosableOutputDevice(pin=GPIO_PIN0)
+    gpio2 = UnclosableOutputDevice(pin=GPIO_PIN2)
 
-        gpio0.off()
-        time.sleep(0.5)
+    gpio2.off()
+    time.sleep(0.5)
 
-        gpio0.on()
-        time.sleep(0.5)
+    gpio0.off()
+    time.sleep(0.5)
+
+    gpio0.on()
+    time.sleep(0.5)
 
 
 def ftdi_set_bitmode(dev, bitmask):

--- a/zigpy_zigate/common.py
+++ b/zigpy_zigate/common.py
@@ -31,6 +31,7 @@ class UnclosableOutputDevice(OutputDevice):
             pin_factory=pin_factory,
         )
         self._pin.close = lambda *args, **kwargs: None
+        self.pin_factory.close = lambda *args, **kwargs: None
 
 
 def discover_port():

--- a/zigpy_zigate/tools/flasher.py
+++ b/zigpy_zigate/tools/flasher.py
@@ -20,17 +20,6 @@ from zigpy_zigate import common as c
 import time
 import serial
 from serial.tools.list_ports import comports
-try:
-    import RPi.GPIO as GPIO
-except Exception:
-    # Fake GPIO
-    class GPIO:
-        def fake(self, *args, **kwargs):
-            pass
-
-        def __getattr__(self, *args, **kwargs):
-            return self.fake
-    GPIO = GPIO()
 import usb
 
 
@@ -419,19 +408,6 @@ def upgrade_firmware(port):
     print('ZiGate flashed with {}'.format(firmware_path))
 
 
-def ftdi_set_bitmode(dev, bitmask):
-    '''
-    Set mode for ZiGate DIN module
-    '''
-    BITMODE_CBUS = 0x20
-    SIO_SET_BITMODE_REQUEST = 0x0b
-    bmRequestType = usb.util.build_request_type(usb.util.CTRL_OUT,
-                                                usb.util.CTRL_TYPE_VENDOR,
-                                                usb.util.CTRL_RECIPIENT_DEVICE)
-    wValue = bitmask | (BITMODE_CBUS << BITMODE_CBUS)
-    dev.ctrl_transfer(bmRequestType, SIO_SET_BITMODE_REQUEST, wValue)
-
-
 def main():
     ports_available = [port for (port, _, _) in sorted(comports())]
     parser = argparse.ArgumentParser()
@@ -452,33 +428,9 @@ def main():
         LOGGER.setLevel(logging.DEBUG)
 
     if args.gpio:
-        LOGGER.info('Put PiZiGate in flash mode')
-        GPIO.setmode(GPIO.BCM)
-        GPIO.setup(27, GPIO.OUT)  # GPIO2
-        GPIO.output(27, GPIO.LOW)  # GPIO2
-        GPIO.setup(17, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)  # GPIO0
-        time.sleep(0.5)
-        GPIO.setup(17, GPIO.IN, pull_up_down=GPIO.PUD_UP)  # GPIO0
-        time.sleep(0.5)
+        c.set_pizigate_flashing_mode._sync_func()
     elif args.din:
-        LOGGER.info('Put ZiGate DIN in flash mode')
-        dev = usb.core.find(idVendor=0x0403, idProduct=0x6001)
-        if not dev:
-            LOGGER.error('ZiGate DIN not found.')
-            return
-        ftdi_set_bitmode(dev, 0x00)
-        time.sleep(0.5)
-        # Set CBUS2/3 high...
-        ftdi_set_bitmode(dev, 0xCC)
-        time.sleep(0.5)
-        # Set CBUS2/3 low...
-        ftdi_set_bitmode(dev, 0xC0)
-        time.sleep(0.5)
-        ftdi_set_bitmode(dev, 0xC4)
-        time.sleep(0.5)
-        # Set CBUS2/3 back to tristate
-        ftdi_set_bitmode(dev, 0xCC)
-        time.sleep(0.5)
+        c.set_zigatedin_flashing_mode._sync_func()
 
     if args.upgrade:
         upgrade_firmware(args.serialport)
@@ -508,18 +460,9 @@ def main():
 #             erase_EEPROM(ser, args.pdm_only)
 
     if args.gpio:
-        LOGGER.info('Put PiZiGate in running mode')
-        GPIO.output(27, GPIO.HIGH)  # GPIO2
-        GPIO.setup(17, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)  # GPIO0
-        time.sleep(0.5)
-        GPIO.setup(17, GPIO.IN, pull_up_down=GPIO.PUD_UP)  # GPIO0
-        time.sleep(0.5)
+        c.set_pizigate_running_mode._sync_func()
     elif args.din:
-        LOGGER.info('Put ZiGate DIN in running mode')
-        ftdi_set_bitmode(dev, 0xC8)
-        time.sleep(0.5)
-        ftdi_set_bitmode(dev, 0xCC)
-        time.sleep(0.5)
+        c.set_zigatedin_running_mode._sync_func()
 
 
 if __name__ == "__main__":

--- a/zigpy_zigate/tools/flasher.py
+++ b/zigpy_zigate/tools/flasher.py
@@ -428,9 +428,9 @@ def main():
         LOGGER.setLevel(logging.DEBUG)
 
     if args.gpio:
-        c.set_pizigate_flashing_mode._sync_func()
+        c.set_pizigate_flashing_mode()
     elif args.din:
-        c.set_zigatedin_flashing_mode._sync_func()
+        c.set_zigatedin_flashing_mode()
 
     if args.upgrade:
         upgrade_firmware(args.serialport)
@@ -460,9 +460,9 @@ def main():
 #             erase_EEPROM(ser, args.pdm_only)
 
     if args.gpio:
-        c.set_pizigate_running_mode._sync_func()
+        c.set_pizigate_running_mode()
     elif args.din:
-        c.set_zigatedin_running_mode._sync_func()
+        c.set_zigatedin_running_mode()
 
 
 if __name__ == "__main__":

--- a/zigpy_zigate/uart.py
+++ b/zigpy_zigate/uart.py
@@ -156,13 +156,13 @@ async def connect(device_config: Dict[str, Any], api, loop=None):
     else:
         if c.is_pizigate(port):
             LOGGER.debug('PiZiGate detected')
-            await c.set_pizigate_running_mode()
+            await c.async_set_pizigate_running_mode()
             # in case of pizigate:/dev/ttyAMA0 syntax
             if port.startswith('pizigate:'):
                 port = port[9:]
         elif c.is_zigate_din(port):
             LOGGER.debug('ZiGate USB DIN detected')
-            await c.set_zigatedin_running_mode()
+            await c.async_set_zigatedin_running_mode()
 
         _, protocol = await serial_asyncio.create_serial_connection(
             loop,


### PR DESCRIPTION
https://github.com/home-assistant/core/issues/75967

`gpiozero` is pure-Python and can be installed on any platform, removing the need for the conditional requirements in the `setup.py` file.

I don't have a GPIO or DIN ZiGate to test with so this is a blind implementation. It should work but I would appreciate someone testing it out.