### PR TITLE
Fix typo in GPIO pin configuration kwargs and add unit test

### DIFF
--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -1,6 +1,7 @@
 from .async_mock import MagicMock, AsyncMock
 
 import pytest
+import gpiozero
 import serial_asyncio
 import serial.tools.list_ports
 
@@ -173,3 +174,10 @@ def test_is_not_zigate_wifi():
     port = '/dev/ttyUSB1'
     r = common.is_zigate_wifi(port)
     assert r is False
+
+
+def test_startup_gpio_toggling(monkeypatch):
+    monkeypatch.setattr(gpiozero.Device, '_default_pin_factory', MagicMock())
+
+    common.set_pizigate_running_mode()
+    common.set_pizigate_flashing_mode()

--- a/zigpy_zigate/common.py
+++ b/zigpy_zigate/common.py
@@ -81,8 +81,8 @@ def is_zigate_wifi(port):
 def set_pizigate_running_mode():
     LOGGER.info('Put PiZiGate in running mode')
 
-    gpio0 = UnclosableOutputDevice(pin=GPIO_PIN0, initial_state=None)
-    gpio2 = UnclosableOutputDevice(pin=GPIO_PIN2, initial_state=None)
+    gpio0 = UnclosableOutputDevice(pin=GPIO_PIN0, initial_value=None)
+    gpio2 = UnclosableOutputDevice(pin=GPIO_PIN2, initial_value=None)
 
     gpio2.on()
     time.sleep(0.5)
@@ -97,8 +97,8 @@ def set_pizigate_running_mode():
 def set_pizigate_flashing_mode():
     LOGGER.info('Put PiZiGate in flashing mode')
 
-    gpio0 = UnclosableOutputDevice(pin=GPIO_PIN0, initial_state=None)
-    gpio2 = UnclosableOutputDevice(pin=GPIO_PIN2, initial_state=None)
+    gpio0 = UnclosableOutputDevice(pin=GPIO_PIN0, initial_value=None)
+    gpio2 = UnclosableOutputDevice(pin=GPIO_PIN2, initial_value=None)
 
     gpio2.off()
     time.sleep(0.5)


### PR DESCRIPTION
#125 contained a last-minute typo that was not caught by unit tests.