### PR TITLE
Ensure `disconnect` can be called multiple times

### DIFF
--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -50,7 +50,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
     async def disconnect(self):
         # TODO: how do you stop the network? Is it possible?
 
-        if self._api:
+        if self._api is not None:
             try:
                 await self._api.reset(wait=False)
             except Exception as e:

--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -49,11 +49,15 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     async def disconnect(self):
         # TODO: how do you stop the network? Is it possible?
-        await self._api.reset(wait=False)
 
         if self._api:
-            self._api.close()
-            self._api = None
+            try:
+                await self._api.reset(wait=False)
+            except Exception as e:
+                LOGGER.warning("Failed to reset before disconnect: %s", e)
+            finally:
+                self._api.close()
+                self._api = None
 
     async def start_network(self):
         # TODO: how do you start the network? Is it always automatically started?


### PR DESCRIPTION
`disconnect` should work even if the port is already disconnected (i.e. in a context manager where it's always called to clean up).