### PR TITLE
Implement new zigpy packet API

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        version: 3.7
+        version: 3.8
     - name: Install wheel
       run: >-
         pip install wheel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'pyserial-asyncio>=0.5; platform_system!="Windows"',
         'pyserial-asyncio!=0.5; platform_system=="Windows"',  # 0.5 broke writes
         'pyusb>=1.1.0',
-        'zigpy>=0.47.0',
+        'zigpy>=0.51.0',
         'gpiozero',
     ],
     tests_require=[

--- a/zigpy_zigate/api.py
+++ b/zigpy_zigate/api.py
@@ -67,6 +67,10 @@ class ResponseId(enum.IntEnum):
     EXTENDED_ERROR = 0x9999
 
 
+class SendSecurity(t.uint8_t, enum.Enum):
+    NETWORK = 0x00
+    APPLINK = 0x01
+    TEMP_APPLINK = 0x02
 
 
 class NonFactoryNewRestartStatus(t.uint8_t, enum.Enum):
@@ -482,11 +486,10 @@ class ZiGate:
         return await self.command(CommandId.NETWORK_REMOVE_DEVICE, data)
 
     async def raw_aps_data_request(self, addr, src_ep, dst_ep, profile,
-                                   cluster, payload, addr_mode=2, security=0):
+                                   cluster, payload, addr_mode=t.AddressMode.NWK, security=SendSecurity.NETWORK, radius=0):
         '''
         Send raw APS Data request
         '''
-        radius = 0
         data = t.serialize([addr_mode, addr,
                            src_ep, dst_ep, cluster, profile,
                            security, radius, payload], COMMANDS[CommandId.SEND_RAW_APS_DATA_PACKET])

--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -115,11 +115,13 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             self.state.network_info.children.append(ieee)
             self.state.network_info.nwk_addresses[ieee] = zigpy.types.NWK(device.short_addr)
 
+    async def reset_network_info(self):
+        await self._api.erase_persistent_data()
+
     async def write_network_info(self, *, network_info, node_info):
         LOGGER.warning('Setting the pan_id is not supported by ZiGate')
 
-        await self._api.erase_persistent_data()
-
+        await self.reset_network_info()
         await self._api.set_channel(network_info.channel)
 
         epid, _ = zigpy.types.uint64_t.deserialize(network_info.extended_pan_id.serialize())

--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -179,28 +179,30 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             #     LOGGER.debug('Start pairing {} (1st device announce)'.format(nwk))
             #     self._pending_join.append(nwk)
         elif msg == ResponseId.DATA_INDICATION:
-            if response[1] == 0x0 and response[2] == 0x13:
-                nwk = zigpy.types.NWK(response[5].address)
-                ieee = zigpy.types.EUI64(response[7][3:11])
-                parent_nwk = 0
-                self.handle_join(nwk, ieee, parent_nwk)
-                return
-            try:
-                if response[5].address_mode == t.AddressMode.NWK:
-                    device = self.get_device(nwk = zigpy.types.NWK(response[5].address))
-                elif response[5].address_mode == t.AddressMode.IEEE:
-                    device = self.get_device(ieee=zigpy.types.EUI64(response[5].address))
-                else:
-                    LOGGER.error("No such device %s", response[5].address)
-                    return
-            except KeyError:
-                LOGGER.debug("No such device %s", response[5].address)
-                return
-            rssi = 0
-            device.radio_details(lqi, rssi)
-            self.handle_message(device, response[1],
-                                response[2],
-                                response[3], response[4], response[-1])
+            (
+                status,
+                profile_id,
+                cluster_id,
+                src_ep,
+                dst_ep,
+                src,
+                dst,
+                payload,
+            ) = response
+
+            packet = zigpy.types.ZigbeePacket(
+                src=src.to_zigpy_type()[0],
+                src_ep=src_ep,
+                dst=dst.to_zigpy_type()[0],
+                dst_ep=dst_ep,
+                profile_id=profile_id,
+                cluster_id=cluster_id,
+                data=zigpy.types.SerializableBytes(payload),
+                lqi=lqi,
+                rssi=None,
+            )
+
+            self.packet_received(packet)
         elif msg == ResponseId.ACK_DATA:
             LOGGER.debug('ACK Data received %s %s', response[4], response[0])
             # disabled because of https://github.com/fairecasoimeme/ZiGate/issues/324
@@ -228,32 +230,44 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         except asyncio.futures.InvalidStateError as exc:
             LOGGER.debug("Invalid state on future - probably duplicate response: %s", exc)
 
-    @zigpy.util.retryable_request
-    async def request(self, device, profile, cluster, src_ep, dst_ep, sequence, data,
-                      expect_reply=True, use_ieee=False):
-        return await self._request(device.nwk, profile, cluster, src_ep, dst_ep, sequence, data,
-        expect_reply, use_ieee)
+    async def send_packet(self, packet):
+        LOGGER.debug("Sending packet %r", packet)
 
-    async def mrequest(self, group_id, profile, cluster, src_ep, sequence, data, *, hops=0, non_member_radius=3):
-        src_ep = 1
-        return await self._request(group_id, profile, cluster, src_ep, src_ep, sequence, data, addr_mode=1)
-    
-    async def _request(self, nwk, profile, cluster, src_ep, dst_ep, sequence, data,
-                      expect_reply=True, use_ieee=False, addr_mode=2):
-        src_ep = 1 if dst_ep else 0  # ZiGate only support endpoint 1
-        LOGGER.debug('request %s',
-                     (nwk, profile, cluster, src_ep, dst_ep, sequence, data, expect_reply, use_ieee))
+        if packet.dst.addr_mode == zigpy.types.AddrMode.IEEE:
+            LOGGER.warning("IEEE addressing is not supported, falling back to NWK")
+
+            try:
+                device = self.get_device_with_address(packet.dst)
+            except (KeyError, ValueError):
+                raise ValueError(f"Cannot find device with IEEE {packet.dst.address}")
+
+            packet = packet.replace(
+                dst=zigpy.types.AddrModeAddress(
+                    addr_mode=zigpy.types.AddrMode.NWK, address=device.nwk
+                )
+            )
+
+        ack = (zigpy.types.TransmitOptions.ACK in packet.tx_options)
+
         try:
-            v, lqi = await self._api.raw_aps_data_request(nwk, src_ep, dst_ep, profile, cluster, data, addr_mode)
+            (status, tsn, packet_type, _), _ = await self._api.raw_aps_data_request(
+                addr=packet.dst.address,
+                src_ep=(1 if packet.dst_ep > 0 else 0),  # ZiGate only support endpoint 1
+                dst_ep=packet.dst_ep,
+                profile=packet.profile_id,
+                cluster=packet.cluster_id,
+                payload=packet.data.serialize(),
+                addr_mode=t.ZIGPY_TO_ZIGATE_ADDR_MODE[packet.dst.addr_mode, ack],
+                radius=packet.radius,
+            )
         except NoResponseError:
-            return 1, "ZiGate doesn't answer to command"
-        req_id = v[1]
-        send_fut = asyncio.Future()
-        self._pending[req_id] = send_fut
+            raise zigpy.exceptions.DeliveryError("ZiGate did not respond to command")
 
-        if v[0] != t.Status.Success:
-            self._pending.pop(req_id)
-            return v[0], "Message send failure {}".format(v[0])
+        if status != t.Status.Success:
+            self._pending.pop(tsn)
+            raise zigpy.exceptions.DeliveryError(f"Failed to deliver packet: {status}", status=status)
+
+        self._pending[tsn] = asyncio.get_running_loop().create_future()
 
         # disabled because of https://github.com/fairecasoimeme/ZiGate/issues/324
         # try:
@@ -261,19 +275,14 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         # except asyncio.TimeoutError:
         #     return 1, "timeout waiting for message %s send ACK" % (sequence, )
         # finally:
-        #     self._pending.pop(req_id)
+        #     self._pending.pop(tsn)
         # return v, "Message sent"
-        return 0, "Message sent"
 
     async def permit_ncp(self, time_s=60):
         assert 0 <= time_s <= 254
         status, lqi = await self._api.permit_join(time_s)
         if status[0] != t.Status.Success:
             await self._api.reset()
-
-    async def broadcast(self, profile, cluster, src_ep, dst_ep, grpid, radius,
-                        sequence, data, broadcast_address):
-        LOGGER.debug("Broadcast not implemented.")
 
 
 class ZiGateDevice(zigpy.device.Device):


### PR DESCRIPTION
Once https://github.com/zigpy/zigpy/pull/1043 is merged and a new zigpy version is released this PR can be merged.

Prior to this change, broadcast was not implemented in zigpy-zigate. It should be functional now that the correct address mode is implemented, but it is not: the packet is correctly sent with the appropriate address mode and a non-zero radius, but I cannot see it with a sniffer.

This has the unfortunate side effect of not allowing you to permit joins through any device other than the coordinator.

@pipiche38