### PR TITLE
Fix exception when sending group requests

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -2,11 +2,12 @@ from unittest.mock import AsyncMock, MagicMock, patch, sentinel
 
 import pytest
 import logging
-import zigpy.types as zigpy_types
+import zigpy.types as zigpy_t
 import zigpy.exceptions
 
-import zigpy_zigate.config as config
+import zigpy_zigate.api
 import zigpy_zigate.types as t
+import zigpy_zigate.config as config
 import zigpy_zigate.zigbee.application
 
 APP_CONFIG = zigpy_zigate.zigbee.application.ControllerApplication.SCHEMA(
@@ -22,7 +23,7 @@ FAKE_FIRMWARE_VERSION = '3.1z'
 def app():
     a = zigpy_zigate.zigbee.application.ControllerApplication(APP_CONFIG)
     a.version = FAKE_FIRMWARE_VERSION
-    a._api = MagicMock()
+    a._api = MagicMock(spec_set=zigpy_zigate.api.ZiGate)
     return a
 
 
@@ -32,7 +33,7 @@ def test_zigpy_ieee(app):
     data = b"\x01\x02\x03\x04\x05\x06\x07\x08"
 
     zigate_ieee, _ = t.EUI64.deserialize(data)
-    app.state.node_info.ieee = zigpy_types.EUI64(zigate_ieee)
+    app.state.node_info.ieee = zigpy_t.EUI64(zigate_ieee)
 
     dst_addr = app.get_dst_address(cluster)
     assert dst_addr.serialize() == b"\x03" + data[::-1] + b"\x01"
@@ -149,3 +150,13 @@ async def test_startup_connect(zigate_new, app, version_rsp, expected_version):
     await app.connect()
 
     assert app.version == expected_version
+
+
+@pytest.mark.asyncio
+async def test_send_group_request(app):
+    packet = zigpy_t.ZigbeePacket(src=None, src_ep=1, dst=zigpy_t.AddrModeAddress(addr_mode=zigpy_t.AddrMode.Group, address=0x0002), dst_ep=None, source_route=None, extended_timeout=False, tsn=21, profile_id=260, cluster_id=6, data=zigpy_t.SerializableBytes(b'\x01\x15\x00'), tx_options=zigpy_t.TransmitOptions.NONE, radius=0, non_member_radius=3, lqi=None, rssi=None)
+
+    app._api.raw_aps_data_request.return_value = ([t.Status.Success, 0, 1328, b'\x01\xea\x00\x00'], 0)
+    await app.send_packet(packet)
+
+    app._api.raw_aps_data_request.assert_called_once()

--- a/zigpy_zigate/api.py
+++ b/zigpy_zigate/api.py
@@ -290,13 +290,12 @@ class ZiGate:
         self._app = app
 
     def data_received(self, cmd, data, lqi):
-        LOGGER.debug("data received %s %s LQI:%s", hex(cmd),
-                     binascii.hexlify(data), lqi)
         if cmd not in RESPONSES:
-            LOGGER.warning('Received unhandled response 0x%04x', cmd)
+            LOGGER.warning('Received unhandled response 0x%04x: %r', cmd, binascii.hexlify(data))
             return
         cmd = ResponseId(cmd)
         data, rest = t.deserialize(data, RESPONSES[cmd])
+        LOGGER.debug("Response received: %s %s %s (LQI:%s)", cmd, data, rest, lqi)
         if cmd == ResponseId.STATUS:
             if data[2] in self._status_awaiting:
                 fut = self._status_awaiting.pop(data[2])

--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -243,8 +243,8 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         try:
             (status, tsn, packet_type, _), _ = await self._api.raw_aps_data_request(
                 addr=packet.dst.address,
-                src_ep=(1 if packet.dst_ep > 0 else 0),  # ZiGate only support endpoint 1
-                dst_ep=packet.dst_ep,
+                src_ep=(1 if packet.dst_ep is None or packet.dst_ep > 0 else 0),  # ZiGate only support endpoint 1
+                dst_ep=packet.dst_ep or 0,
                 profile=packet.profile_id,
                 cluster=packet.cluster_id,
                 payload=packet.data.serialize(),


### PR DESCRIPTION
Group requests don't work when downgrading to 2022.9.7 so this change is entirely to prevent an error from being thrown:

```Python
2022-10-10 12:24:45.058 DEBUG (MainThread) [zigpy_zigate.zigbee.application] Sending packet ZigbeePacket(src=None, src_ep=1, dst=AddrModeAddress(addr_mode=<AddrMode.Group: 1>, address=0x0002), dst_ep=None, source_route=None, extended_timeout=False, tsn=37, profile_id=260, cluster_id=6, data=Serialized[b'\x01%\x00'], tx_options=<TransmitOptions.NONE: 0>, radius=0, non_member_radius=3, lqi=None, rssi=None)
2022-10-10 12:24:45.058 DEBUG (MainThread) [zigpy_zigate.api] Sending CommandId.SEND_RAW_APS_DATA_PACKET (b'\x01\x00\x02\x01\x00\x00\x06\x01\x04\x00\x00\x03\x01%\x00'), waiting for status: True, waiting for response: None
2022-10-10 12:24:45.058 DEBUG (MainThread) [zigpy_zigate.api] Wait for status to command CommandId.SEND_RAW_APS_DATA_PACKET
2022-10-10 12:24:45.094 DEBUG (MainThread) [zigpy_zigate.api] Response received: ResponseId.STATUS [<Status.Success: 0>, 0, 1328, b'\x01\xea\x00\x00'] 0 (LQI:b'')
```

Sniffer shows no traffic leaving ZiGate.

@doudz Are multicast/group requests expected to work?