### PR TITLE
register zigpy endpoints at startup

### DIFF
--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -11,6 +11,7 @@ import zigpy.types
 import zigpy.util
 import zigpy.zdo
 import zigpy.exceptions
+import zigpy.zdo.types as zdo_t
 
 import zigpy_zigate
 from zigpy_zigate import types as t


### PR DESCRIPTION
This PR is similar to https://github.com/zigpy/zigpy-xbee/pull/145
While I don't have a zigate radio and thus cannot test, looking into the code it looks like it is also affected by the same problem.
The PR registers zigpy endpoints on network start.