### PR TITLE
Fix blocking metadata version call

### DIFF
--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -22,6 +22,7 @@ from zigpy_zigate.config import (
     SCHEMA_DEVICE,
 )
 
+LIB_VERSION = importlib.metadata.version("zigpy-zigate")
 LOGGER = logging.getLogger(__name__)
 
 
@@ -91,7 +92,7 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         )
 
         self.state.network_info = zigpy.state.NetworkInfo(
-            source=f"zigpy-zigate@{importlib.metadata.version('zigpy-zigate')}",
+            source=f"zigpy-zigate@{LIB_VERSION}",
             extended_pan_id=epid,
             pan_id=zigpy.types.PanId(network_state[2]),
             nwk_update_id=0,


### PR DESCRIPTION
This moves the blocking metadata version call outside of the load_network_info coroutine that's run at startup.
And it's also a good test run to see if tests are still working with the latest zigpy.