### PR TITLE
Fix blocking event loop calls

### DIFF
--- a/zigpy_zigate/api.py
+++ b/zigpy_zigate/api.py
@@ -592,15 +592,5 @@ class ZiGate:
 
     async def _probe(self) -> None:
         """Open port and try sending a command"""
-        try:
-            device = next(
-                serial.tools.list_ports.grep(
-                    self._config[zigpy_zigate.config.CONF_DEVICE_PATH]
-                )
-            )
-            if device.description == "ZiGate":
-                return
-        except StopIteration:
-            pass
         await self.connect()
         await self.set_raw_mode()

--- a/zigpy_zigate/uart.py
+++ b/zigpy_zigate/uart.py
@@ -141,7 +141,7 @@ async def connect(device_config: Dict[str, Any], api, loop=None):
 
     port = device_config[CONF_DEVICE_PATH]
     if port == "auto":
-        port = c.discover_port()
+        port = await loop.run_in_executor(None, c.discover_port)
 
     if c.is_pizigate(port):
         LOGGER.debug("PiZiGate detected")


### PR DESCRIPTION
Likely the cause of the warning logged here https://github.com/home-assistant/core/issues/121316

Note that this is just a warning. The event loop is not blocked for more than a few hundred microseconds so this will not cause communication issues with ZHA.