### PR TITLE
Move more sync functions to executor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     with:
       CODE_FOLDER: zigpy_zigate
       CACHE_VERSION: 2
-      PYTHON_VERSION_DEFAULT: 3.8.14
       PRE_COMMIT_CACHE_PATH:  ~/.cache/pre-commit
       MINIMUM_COVERAGE_PERCENTAGE: 46
     secrets:

--- a/tests/test_uart.py
+++ b/tests/test_uart.py
@@ -22,6 +22,8 @@ def gw():
     ("/dev/null", "pizigate:/dev/ttyAMA0"),
 )
 async def test_connect(port, monkeypatch):
+    monkeypatch.setattr(gpiozero.Device, "_default_pin_factory", MagicMock())
+
     api = MagicMock()
 
     async def mock_conn(loop, protocol_factory, url, **kwargs):

--- a/zigpy_zigate/common.py
+++ b/zigpy_zigate/common.py
@@ -174,3 +174,5 @@ async_set_pizigate_running_mode = async_run_in_executor(set_pizigate_running_mod
 async_set_pizigate_flashing_mode = async_run_in_executor(set_pizigate_flashing_mode)
 async_set_zigatedin_running_mode = async_run_in_executor(set_zigatedin_running_mode)
 async_set_zigatedin_flashing_mode = async_run_in_executor(set_zigatedin_flashing_mode)
+async_is_pizigate = async_run_in_executor(is_pizigate)
+async_is_zigate_din = async_run_in_executor(is_zigate_din)

--- a/zigpy_zigate/common.py
+++ b/zigpy_zigate/common.py
@@ -162,7 +162,7 @@ def async_run_in_executor(function):
     """Decorator to make a sync function async."""
 
     async def replacement(*args):
-        return asyncio.get_running_loop().run_in_executor(None, function, *args)
+        return await asyncio.get_running_loop().run_in_executor(None, function, *args)
 
     replacement._sync_func = function
 

--- a/zigpy_zigate/uart.py
+++ b/zigpy_zigate/uart.py
@@ -142,13 +142,13 @@ async def connect(device_config: Dict[str, Any], api, loop=None):
     if port == "auto":
         port = await loop.run_in_executor(None, c.discover_port)
 
-    if c.is_pizigate(port):
+    if await c.async_is_pizigate(port):
         LOGGER.debug("PiZiGate detected")
         await c.async_set_pizigate_running_mode()
         # in case of pizigate:/dev/ttyAMA0 syntax
         if port.startswith("pizigate:"):
             port = port.replace("pizigate:", "", 1)
-    elif c.is_zigate_din(port):
+    elif await c.async_is_zigate_din(port):
         LOGGER.debug("ZiGate USB DIN detected")
         await c.async_set_zigatedin_running_mode()
     elif c.is_zigate_wifi(port):

--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -83,9 +83,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
         if c.is_zigate_wifi(port):
             model = "ZiGate WiFi"
-        elif c.is_pizigate(port):
+        elif await c.async_is_pizigate(port):
             model = "PiZiGate"
-        elif c.is_zigate_din(port):
+        elif await c.async_is_zigate_din(port):
             model = "ZiGate USB-DIN"
         else:
             model = "ZiGate USB-TTL"


### PR DESCRIPTION
It appears `is_pizigate` and `is_zigate_din` relied on `glob` and a few other sync calls.

Fixes the (innocuous) warning seen in https://github.com/home-assistant/core/issues/128615