### PR TITLE
Properly disconnect on connection failure

### DIFF
--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -41,10 +41,16 @@ class ControllerApplication(zigpy.application.ControllerApplication):
 
     async def connect(self):
         api = await ZiGate.new(self._config[zigpy.config.CONF_DEVICE], self)
-        await api.set_raw_mode()
-        await api.set_time()
 
-        (_, version), lqi = await api.version()
+        try:
+            await api.set_raw_mode()
+            await api.set_time()
+
+            (_, version), lqi = await api.version()
+        except Exception:
+            await api.disconnect()
+            raise
+
         major, minor = version.to_bytes(2, "big")
         self.version = f"{major:x}.{minor:x}"
 


### PR DESCRIPTION
The radio library currently leaves the serial connection open permanently now that we enforce exclusivity. This should fix instances of ZHA "not working" during adapter setup and requiring a full restart to start functioning again.