### PR TITLE
feat: Add ZiGate+ (v2) Network Recovery support

### DIFF
--- a/zigpy_zigate/api.py
+++ b/zigpy_zigate/api.py
@@ -40,6 +40,8 @@ class CommandId(enum.IntEnum):
     SEND_RAW_APS_DATA_PACKET = 0x0530
     AHI_SET_TX_POWER = 0x0806
     GET_NETWORK_KEY = 0x0054
+    NETWORK_RECOVERY_EXTRACT = 0x0600
+    NETWORK_RECOVERY_RESTORE = 0x0601
 
 
 class ResponseId(enum.IntEnum):
@@ -67,6 +69,8 @@ class ResponseId(enum.IntEnum):
     AHI_SET_TX_POWER_RSP = 0x8806
     EXTENDED_ERROR = 0x9999
     GET_NETWORK_KEY_LIST = 0x8054
+    NETWORK_RECOVERY_EXTRACT_RSP = 0x8600
+    NETWORK_RECOVERY_RESTORE_RSP = 0x8601
 
 
 class SendSecurity(t.uint8_t, enum.Enum):
@@ -145,6 +149,8 @@ RESPONSES = {
     ResponseId.AHI_SET_TX_POWER_RSP: (t.uint8_t,),
     ResponseId.EXTENDED_ERROR: (t.Status,),
     ResponseId.GET_NETWORK_KEY_LIST: (zigpy.types.KeyData,),
+    ResponseId.NETWORK_RECOVERY_EXTRACT_RSP: (t.uint8_t, t.NetworkRecovery),
+    ResponseId.NETWORK_RECOVERY_RESTORE_RSP: (t.uint8_t,),
 }
 
 COMMANDS = {
@@ -546,3 +552,28 @@ class ZiGate:
             raise CommandNotSupportedError()
 
         return rsp[0]
+
+    async def network_recovery_extract(self) -> t.NetworkRecovery:
+        """Extract network state for backup (ZiGate+ v2, firmware 3.24+)."""
+        rsp, _ = await self.command(
+            CommandId.NETWORK_RECOVERY_EXTRACT,
+            wait_response=ResponseId.NETWORK_RECOVERY_EXTRACT_RSP,
+        )
+
+        status, recovery = rsp[0], rsp[1]
+        if status != 0:
+            raise CommandNotSupportedError(f"Network recovery extract failed: {status}")
+
+        return recovery
+
+    async def network_recovery_restore(self, recovery: t.NetworkRecovery) -> None:
+        """Restore network state from backup (ZiGate+ v2, firmware 3.24+)."""
+        rsp, _ = await self.command(
+            CommandId.NETWORK_RECOVERY_RESTORE,
+            data=recovery.serialize(),
+            wait_response=ResponseId.NETWORK_RECOVERY_RESTORE_RSP,
+        )
+
+        status = rsp[0]
+        if status != 0:
+            raise CommandNotSupportedError(f"Network recovery restore failed: {status}")

--- a/zigpy_zigate/tools/cli.py
+++ b/zigpy_zigate/tools/cli.py
@@ -1,5 +1,5 @@
 """
- Simple CLI ZiGate tool
+Simple CLI ZiGate tool
 """
 
 import argparse

--- a/zigpy_zigate/types.py
+++ b/zigpy_zigate/types.py
@@ -393,3 +393,36 @@ class DeviceEntryArray(tuple):
 
     def serialize(self):
         return b"".join([e.serialize() for e in self])
+
+
+class NetworkRecovery(Struct):
+    """Network Recovery data structure (72 bytes) for ZiGate+ v2 firmware 3.24+."""
+
+    _fields = [
+        # Header (4 bytes)
+        ("version", uint8_t),
+        ("reserved1", uint8_t),
+        ("reserved2", uint8_t),
+        ("reserved3", uint8_t),
+        # Network Identification (20 bytes)
+        ("extended_pan_id", uint64_t),
+        ("ieee_address", uint64_t),
+        ("pan_id", uint16_t),
+        ("nwk_address", uint16_t),
+        # Network Parameters (4 bytes)
+        ("channel", uint8_t),
+        ("nwk_update_id", uint8_t),
+        ("depth", uint8_t),
+        ("capability_info", uint8_t),
+        # Security (20 bytes)
+        ("nwk_key", zigpy.types.KeyData),
+        ("active_key_seq_num", uint8_t),
+        ("security_level", uint8_t),
+        ("reserved4", uint8_t),
+        ("reserved5", uint8_t),
+        # Frame Counters (8 bytes)
+        ("outgoing_frame_counter", uint32_t),
+        ("aps_frame_counter", uint32_t),
+        # Trust Center (8 bytes)
+        ("trust_center_address", uint64_t),
+    ]

--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -83,15 +83,9 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await dev.schedule_initialize()
 
     async def load_network_info(self, *, load_devices: bool = False):
-        # Try Network Recovery for ZiGate+ v2 (firmware 3.24+)
-        recovery = None
+        # Use Network Recovery for ZiGate+ v2 (firmware 3.24+)
         if self.version >= MIN_VERSION_NETWORK_RECOVERY:
-            try:
-                recovery = await self._api.network_recovery_extract()
-            except CommandNotSupportedError:
-                pass
-
-        if recovery is not None:
+            recovery = await self._api.network_recovery_extract()
             await self._load_network_info_from_recovery(recovery, load_devices)
         else:
             await self._load_network_info_legacy(load_devices)
@@ -252,16 +246,11 @@ class ControllerApplication(zigpy.application.ControllerApplication):
             self.version >= MIN_VERSION_NETWORK_RECOVERY
             and "recovery_data" in network_info.stack_specific
         ):
-            try:
-                recovery_bytes = bytes.fromhex(
-                    network_info.stack_specific["recovery_data"]
-                )
-                recovery, _ = t.NetworkRecovery.deserialize(recovery_bytes)
-                await self._api.network_recovery_restore(recovery)
-                LOGGER.info("Network restored via Network Recovery")
-                return
-            except (CommandNotSupportedError, ValueError, KeyError) as e:
-                LOGGER.warning("Network Recovery restore failed: %s", e)
+            recovery_bytes = bytes.fromhex(network_info.stack_specific["recovery_data"])
+            recovery, _ = t.NetworkRecovery.deserialize(recovery_bytes)
+            await self._api.network_recovery_restore(recovery)
+            LOGGER.info("Network restored via Network Recovery")
+            return
 
         # Fall back to legacy method
         await self._write_network_info_legacy(network_info=network_info)

--- a/zigpy_zigate/zigbee/application.py
+++ b/zigpy_zigate/zigbee/application.py
@@ -25,6 +25,9 @@ from zigpy_zigate.api import (
 LIB_VERSION = importlib.metadata.version("zigpy-zigate")
 LOGGER = logging.getLogger(__name__)
 
+# Minimum firmware version for Network Recovery support
+MIN_VERSION_NETWORK_RECOVERY = "3.24"
+
 
 class ControllerApplication(zigpy.application.ControllerApplication):
     def __init__(self, config: dict[str, Any]):
@@ -80,6 +83,94 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await dev.schedule_initialize()
 
     async def load_network_info(self, *, load_devices: bool = False):
+        # Try Network Recovery for ZiGate+ v2 (firmware 3.24+)
+        recovery = None
+        if self.version >= MIN_VERSION_NETWORK_RECOVERY:
+            try:
+                recovery = await self._api.network_recovery_extract()
+            except CommandNotSupportedError:
+                pass
+
+        if recovery is not None:
+            await self._load_network_info_from_recovery(recovery, load_devices)
+        else:
+            await self._load_network_info_legacy(load_devices)
+
+    async def _load_network_info_from_recovery(
+        self, recovery: t.NetworkRecovery, load_devices: bool
+    ):
+        """Load network info from Network Recovery data (ZiGate+ v2)."""
+        port = self._config[zigpy.config.CONF_DEVICE][zigpy.config.CONF_DEVICE_PATH]
+
+        if c.is_zigate_wifi(port):
+            model = "ZiGate WiFi"
+        elif await c.async_is_pizigate(port):
+            model = "PiZiGate"
+        elif await c.async_is_zigate_din(port):
+            model = "ZiGate USB-DIN"
+        else:
+            model = "ZiGate USB-TTL"
+
+        ieee, _ = zigpy.types.EUI64.deserialize(
+            t.uint64_t(recovery.ieee_address).serialize()
+        )
+
+        self.state.node_info = zigpy.state.NodeInfo(
+            nwk=zigpy.types.NWK(recovery.nwk_address),
+            ieee=ieee,
+            logical_type=zigpy.zdo.types.LogicalType.Coordinator,
+            model=model,
+            manufacturer="ZiGate",
+            version=self.version,
+        )
+
+        epid, _ = zigpy.types.ExtendedPanId.deserialize(
+            t.uint64_t(recovery.extended_pan_id).serialize()
+        )
+
+        network_key = zigpy.state.Key(
+            key=recovery.nwk_key,
+            seq=recovery.active_key_seq_num,
+            tx_counter=recovery.outgoing_frame_counter,
+        )
+
+        self.state.network_info = zigpy.state.NetworkInfo(
+            source=f"zigpy-zigate@{LIB_VERSION}",
+            extended_pan_id=epid,
+            pan_id=zigpy.types.PanId(recovery.pan_id),
+            nwk_update_id=recovery.nwk_update_id,
+            nwk_manager_id=zigpy.types.NWK(0x0000),
+            channel=recovery.channel,
+            channel_mask=zigpy.types.Channels.from_channel_list([recovery.channel]),
+            security_level=recovery.security_level,
+            network_key=network_key,
+            children=[],
+            key_table=[],
+            nwk_addresses={},
+            stack_specific={"recovery_data": recovery.serialize().hex()},
+            metadata={"zigate": {"version": self.version}},
+        )
+
+        tc_ieee, _ = zigpy.types.EUI64.deserialize(
+            t.uint64_t(recovery.trust_center_address).serialize()
+        )
+        self.state.network_info.tc_link_key.partner_ieee = tc_ieee
+
+        if not load_devices:
+            return
+
+        for device in await self._api.get_devices_list():
+            if device.power_source != 0:
+                continue
+
+            dev_ieee = zigpy.types.EUI64(device.ieee_addr)
+            self.state.network_info.children.append(dev_ieee)
+            self.state.network_info.nwk_addresses[dev_ieee] = zigpy.types.NWK(
+                device.short_addr
+            )
+
+    async def _load_network_info_legacy(self, load_devices: bool):
+        """Load network info using legacy method (older firmwares)."""
         network_state, lqi = await self._api.get_network_state()
 
         if not network_state or network_state[3] == 0 or network_state[0] == 0xFFFF:
@@ -156,6 +247,27 @@ class ControllerApplication(zigpy.application.ControllerApplication):
         await self._api.erase_persistent_data()
 
     async def write_network_info(self, *, network_info, node_info):
+        # Try Network Recovery restore for ZiGate+ v2 (firmware 3.24+)
+        if (
+            self.version >= MIN_VERSION_NETWORK_RECOVERY
+            and "recovery_data" in network_info.stack_specific
+        ):
+            try:
+                recovery_bytes = bytes.fromhex(
+                    network_info.stack_specific["recovery_data"]
+                )
+                recovery, _ = t.NetworkRecovery.deserialize(recovery_bytes)
+                await self._api.network_recovery_restore(recovery)
+                LOGGER.info("Network restored via Network Recovery")
+                return
+            except (CommandNotSupportedError, ValueError, KeyError) as e:
+                LOGGER.warning("Network Recovery restore failed: %s", e)
+
+        # Fall back to legacy method
+        await self._write_network_info_legacy(network_info=network_info)
+
+    async def _write_network_info_legacy(self, *, network_info):
+        """Write network info using legacy method (older firmwares)."""
         LOGGER.warning("Setting the pan_id is not supported by ZiGate")
 
         await self.reset_network_info()


### PR DESCRIPTION
Add Network Recovery for ZiGate+ v2 (firmware 3.24+) to enable coordinator backup/restore without re-pairing devices.

Changes:
- types.py: Add NetworkRecovery Struct (72-byte network state)
- api.py: Add NETWORK_RECOVERY_EXTRACT/RESTORE commands and methods
- application.py: Integrate with load_network_info/write_network_info

The recovery data is stored in stack_specific["recovery_data"] and used automatically when restoring a network backup on compatible firmware. Falls back to legacy method on older firmwares.

https://github.com/zigpy/zigpy-zigate/issues/164